### PR TITLE
Tidy up repo on clone

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 25.2
+elixir 1.14.2-otp-25

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Scientist.Mixfile do
     [
       app: :scientist,
       version: "0.2.1",
-      elixir: "~> 1.2",
+      elixir: "~> 1.10",
       deps: deps(),
       package: package(),
       name: "Scientist",

--- a/test/experiment_test.exs
+++ b/test/experiment_test.exs
@@ -52,17 +52,6 @@ defmodule ExperimentTest do
     end)
   end
 
-  test "the exception stacktrace is unchanged in the control" do
-    assert_raise(RuntimeError, fn ->
-      Experiment.new()
-      |> Experiment.add_control(fn -> raise "control" end)
-      |> Experiment.add_candidate(fn -> :candidate end)
-      |> Experiment.run()
-    end)
-
-    assert match?([{ExperimentTest, _, _, _} | _], System.stacktrace())
-  end
-
   test "it passes through thrown exceptions in the control" do
     catch_throw(
       Experiment.new()


### PR DESCRIPTION
Updates *minimum* elixir version to 1.10, and removes test of no-longer-possible stacktrace sharing